### PR TITLE
docs: fix wrong ubuntu version

### DIFF
--- a/docs/docs/reference/os-ubuntu-images/ubuntu-2404-image.md
+++ b/docs/docs/reference/os-ubuntu-images/ubuntu-2404-image.md
@@ -28,7 +28,7 @@ To use this operating system, and choose `ubuntu2404` in the **OS Image** select
 </TabItem>
 <TabItem value="yaml" label="YAML">
 
-To use this operating system,  you must select an [`f1-standard`] machine and use `ubuntu2204` as the `os_image`:
+To use this operating system, you must select an [`f1-standard`] machine and use `ubuntu2404` as the `os_image`:
 
 ```yaml
 version: 1.0


### PR DESCRIPTION
## 📝 Description
A Semaphore user pointed out this mistake in our documentation, where the wrong Ubuntu version is referenced on this page.

## ✅ Checklist
- [X] I have tested this change
- [ ] This change requires documentation update
